### PR TITLE
Checks if the resource has datastore_active to display Basic Grid view.

### DIFF
--- a/ckanext/basiccharts/plugin.py
+++ b/ckanext/basiccharts/plugin.py
@@ -161,7 +161,7 @@ class BasicGrid(p.SingletonPlugin):
                 }
 
     def can_view(self, data_dict):
-        return True
+        return data_dict['resource'].get('datastore_active', False)
 
     def view_template(self, context, data_dict):
         return 'basicgrid_view.html'


### PR DESCRIPTION
Implements the `can_view` in the BasicGrid plugin to check if the resource is active on the data-store - basic grid can only display the view if the data is present in the data store.